### PR TITLE
Dockerfile: remove ADD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,1 @@
 FROM google/nodejs-runtime
-ADD . /home/vmagent/nodejs-application/
-


### PR DESCRIPTION
ADD is not necessary since `google/nodejs-runtime` do `ONBUILD`
