### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ Start by cloning this repository.
 To run the app locally in the dev appserver:
 
 ~~~~
-gcloud preview app run .
+gcloud preview app run app.yaml
 ~~~~
 
 If needed, you can enable debug output:
 
 ~~~~
-gcloud --verbosity debug preview app run .
+gcloud --verbosity debug preview app run app.yaml
 ~~~~
 
 To deploy the app in production:
 
 ~~~~
-gcloud --project YOUR-PROJECT-NAME-HERE preview app deploy .
+gcloud --project YOUR-PROJECT-NAME-HERE preview app deploy app.yaml
 ~~~~
 
 ## Application layout


### PR DESCRIPTION
Current version of Google Cloud SDK seems to require explicit yaml file.

ERROR: Directories are not supported [.].  You must provide explicit yaml files.
ERROR: (gcloud.preview.app.run) Errors occurred while parsing the App Engine app configuration.

Google Cloud SDK 0.9.57

alpha 2015.04.09
app 2015.04.21
app-engine-go-darwin-x86_64 1.9.18
app-engine-java 1.9.18
app-engine-python 1.9.18
bq 2.0.18
bq-nix 2.0.18
compute 2015.04.21
core 2015.04.21
core-nix 2014.10.20
dns 2015.04.21
gcloud 2015.04.21
gcloud-extensions-darwin-x86_64 0.15.0
gcutil 1.16.5
gcutil-nix 1.16.5
gsutil 4.11
gsutil-nix 4.6
preview 2015.04.21
sql 2015.04.09